### PR TITLE
Various improvements

### DIFF
--- a/benchmark/uvicorn_server.py
+++ b/benchmark/uvicorn_server.py
@@ -25,7 +25,7 @@ async def app(
 
     # res = endpoint(body)
     res = "hello, world".encode()
-    content_lengh = str(len(res)).encode()
+    content_length = str(len(res)).encode()
 
     # Send response headers
     await send(
@@ -34,7 +34,7 @@ async def app(
             "status": 200,
             "headers": (
                 (b"content-type", b"application/json"),
-                (b"content-length", content_lengh),
+                (b"content-length", content_length),
             ),
         }
     )

--- a/lihil/plugins/premier.py
+++ b/lihil/plugins/premier.py
@@ -6,7 +6,8 @@ from premier.providers import AsyncCacheProvider, AsyncInMemoryCache
 from premier.retry import retry
 from premier.throttler.handler import AsyncDefaultHandler as AsyncDefaultHandler
 from premier.throttler.interface import AsyncThrottleHandler as AsyncThrottleHandler
-from premier.timer.timer import ILogger, timeout
+from premier.timer.interface import ILogger
+from premier.timer.timer import timeout
 
 from lihil.interface import IAsyncFunc, P, R
 from lihil.plugins import IEndpointInfo

--- a/lihil/signature/parser.py
+++ b/lihil/signature/parser.py
@@ -620,7 +620,6 @@ class EndpointParser:
                 param_meta=param_meta,
             )
         elif param_source == "plugin":
-            type_ = type_ or type_
             return PluginParam(
                 type_=type_, annotation=annotation, name=name, default=default
             )

--- a/tests/test_endpoint/test_ep_returns.py
+++ b/tests/test_endpoint/test_ep_returns.py
@@ -5,10 +5,10 @@ import pytest
 
 from lihil import Payload, status
 from lihil.errors import InvalidStatusError, StatusConflictError
+from lihil.interface import CustomEncoder
 from lihil.interface.marks import HTML, Json, Stream, Text
 from lihil.signature.returns import (
     DEFAULT_RETURN,
-    CustomEncoder,
     EndpointReturn,
     agen_encode_wrapper,
     parse_returns,

--- a/tests/test_plugins/test_auth.py
+++ b/tests/test_plugins/test_auth.py
@@ -49,4 +49,4 @@ def test_jwt_missing():
             del sys.modules["lihil.plugins.auth.jwt"]
 
         with pytest.raises(ImportError):
-            from lihil.plugins.auth.jwt import jwt_decoder_factory
+            from lihil.plugins.auth.jwt import jwt_decoder_factory  # type: ignore


### PR DESCRIPTION
- Fix typo in `content_length`
- Remove unused `type_ = type_ or type_`
- Suppress a warning about an intentionally broken import
- Fix some indirect imports to avoid confusion

It's not much, but I hope it helps.